### PR TITLE
Fix: inversion imc final dans medtheCourrierSynthesMT.html.twig

### DIFF
--- a/templates/models4print/medtheCourrierSynthesMT.html.twig
+++ b/templates/models4print/medtheCourrierSynthesMT.html.twig
@@ -41,7 +41,7 @@ Orientation{% if ',' in tag.medtheCouMtOrientations %}s{% endif %} : {{ tag.medt
 <h3>Éléments cliniques</h3>
 
 <p>
-Taille : {{ tag.medtheCouMtTaille }} cm - Poids initial : {{ tag.medtheCouMtPoidsInitial }} kg - Poids final : {{ tag.medtheCouMtPoidsFinal }} kg - IMC Initial : {{ tag.medtheCouMtImcFinal }} kg/m² - IMC Final : {{ tag.medtheCouMtImcInitial }} kg/m²<br>
+Taille : {{ tag.medtheCouMtTaille }} cm - Poids initial : {{ tag.medtheCouMtPoidsInitial }} kg - Poids final : {{ tag.medtheCouMtPoidsFinal }} kg - IMC Initial : {{ tag.medtheCouMtImcInitial }} kg/m² - IMC Final : {{ tag.medtheCouMtImcFinal }} kg/m²<br>
 </p>
 
 <p>


### PR DESCRIPTION
Fix l'inversion des tags medtheCouMtImcFinal et medtheCouMtImcInitial dans le template pour le courrier de synthèse.